### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ If you are using turbo-sprockets, just set it to enabled. Your asset will still 
 set :turbosprockets_enabled, true
 ```
 
+Ensure that assets_role variable is set in config/deploy.rb 
+
+```ruby
+set :assets_role, :app
+```
+
 Here's the full set of configurable options:
 
 ```ruby


### PR DESCRIPTION
This is in reference to an error I've gotten when I have not have assets_role set.

``` bash
/home/davidc/.rvm/gems/ruby-2.0.0-p0/gems/capistrano-2.15.5/lib/capistrano/configuration/namespaces.rb:193:in `method_missing': undefined local variable or method `assets_role' for #<Capistrano::Configuration::Namespaces::Namespace:0x00000002040d60> (NameError)
        from /home/davidc/.rvm/gems/ruby-2.0.0-p0/gems/capistrano-local-precompile-0.0.3/lib/capistrano/local_precompile.rb:46:in `block (4 levels) in load_into'
        from /home/davidc/.rvm/gems/ruby-2.0.0-p0/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
```
