### PR TITLE
Remove old manifest file(s) from shared_path instead of public

### DIFF
--- a/lib/capistrano/local_precompile.rb
+++ b/lib/capistrano/local_precompile.rb
@@ -22,7 +22,7 @@ module Capistrano
 
             desc "remove manifest file from remote server"
             task :remove_manifest do
-              run "rm -f #{fetch(:assets_dir)}/manifest*.json"
+              run "rm -f #{shared_path}/#{shared_assets_prefix}/manifest*"
             end
 
             task :cleanup, :on_no_matching_servers => :continue  do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -47,4 +47,9 @@ describe Capistrano::LocalPrecompile, "configuration" do
     expect(@configuration).to callback('deploy:assets:cleanup').
       after('deploy:assets:precompile')
   end
+
+  it "performs deploy:assets:remove_manifest before deploy:assets:symlink" do
+    expect(@configuration).to callback('deploy:assets:remove_manifest').
+                                  before('deploy:assets:symlink')
+  end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -31,8 +31,11 @@ describe Capistrano::LocalPrecompile, "integration" do
 
   describe 'remove manifest task' do
     it 'invokes the precompile command' do
+      allow(@configuration).to receive(:shared_path).and_return('/tmp/shared')
+      allow(@configuration).to receive(:shared_assets_prefix).and_return('assets')
+
       expect(@configuration).to receive(:run).
-        with('rm -f public/assets/manifest*.json').once
+        with('rm -f /tmp/shared/assets/manifest*').once
 
       @configuration.find_and_execute_task('deploy:assets:remove_manifest')
     end


### PR DESCRIPTION
Remove old manifest file(s) from shared_path instead of public to prevent sprockets from picking the first (oldest) manifest file and to prevent capistrano `deploy:assets:update_asset_mtimes` from throwing an error when it sees multiple manifest files