### PR TITLE
fixed cleanup task for macOS

### DIFF
--- a/lib/capistrano/local_precompile.rb
+++ b/lib/capistrano/local_precompile.rb
@@ -2,7 +2,7 @@ namespace :load do
   task :defaults do
     set :precompile_env,   fetch(:rails_env) || 'production'
     set :assets_dir,       "public/assets"
-    set :packs_dir,        "public/packs"    
+    set :packs_dir,        "public/packs"
     set :rsync_cmd,        "rsync -av --delete"
     set :assets_role,      "web"
 
@@ -18,8 +18,8 @@ namespace :deploy do
     task :cleanup do
       run_locally do
         with rails_env: fetch(:precompile_env) do
-          execute "rm -rf", fetch(:assets_dir)
-          execute "rm -rf", fetch(:packs_dir)
+          execute "rm", "-rf", fetch(:assets_dir)
+          execute "rm", "-rf", fetch(:packs_dir)
         end
       end
     end


### PR DESCRIPTION
It seems that in macOS terminal, the 2nd argument of `execute` is ignored if the first argument has space in.
According to https://capistranorb.com/documentation/getting-started/tasks/ the first argument should not contain space.