### PR TITLE
Enable configuration of :release_path (can now deploy to shared_path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### unreleased:
+
+- Enable configuration of `:assets_release_path` so that it can easily
+  be changed to `:shared_path` or similar
+
 # 1.1.4 / 2018-09-04
 ## Fixed
 - 2nd argument being ignored on OSX

--- a/lib/capistrano/local_precompile.rb
+++ b/lib/capistrano/local_precompile.rb
@@ -1,10 +1,11 @@
 namespace :load do
   task :defaults do
-    set :precompile_env,   fetch(:rails_env) || 'production'
-    set :assets_dir,       "public/assets"
-    set :packs_dir,        "public/packs"
-    set :rsync_cmd,        "rsync -av --delete"
-    set :assets_role,      "web"
+    set :precompile_env,      fetch(:rails_env) || 'production'
+    set :assets_dir,          "public/assets"
+    set :assets_release_path, -> { release_path }
+    set :packs_dir,           "public/packs"
+    set :rsync_cmd,           "rsync -av --delete"
+    set :assets_role,         "web"
 
     after "bundler:install", "deploy:assets:prepare"
     after "deploy:assets:prepare", "deploy:assets:rsync"
@@ -38,8 +39,8 @@ namespace :deploy do
     task :rsync do
       on roles(fetch(:assets_role)) do |server|
         run_locally do
-          execute "#{fetch(:rsync_cmd)} ./#{fetch(:assets_dir)}/ #{server.user}@#{server.hostname}:#{release_path}/#{fetch(:assets_dir)}/" if Dir.exists?(fetch(:assets_dir))
-          execute "#{fetch(:rsync_cmd)} ./#{fetch(:packs_dir)}/ #{server.user}@#{server.hostname}:#{release_path}/#{fetch(:packs_dir)}/" if Dir.exists?(fetch(:packs_dir))
+          execute "#{fetch(:rsync_cmd)} ./#{fetch(:assets_dir)}/ #{server.user}@#{server.hostname}:#{fetch(:assets_release_path)}/#{fetch(:assets_dir)}/" if Dir.exists?(fetch(:assets_dir))
+          execute "#{fetch(:rsync_cmd)} ./#{fetch(:packs_dir)}/ #{server.user}@#{server.hostname}:#{fetch(:assets_release_path)}/#{fetch(:packs_dir)}/" if Dir.exists?(fetch(:packs_dir))
         end
       end
     end


### PR DESCRIPTION
This makes it possible to easily change it to shared directory. Configuration examples

* `set :assets_release_path, -> { release_path }`
* `set :assets_release_path, -> { shared_path }`

* [x] No configurational changes (so you could release this as a minor - enhancement)
* [x] Tested this in a live application of mine, and it works both with and without the configuration line above.

Unfortunately, I could not run the tests locally I got an error (also on the master branch commit 048011e). I am absolutely certain it had nothing to do with this specific change.