### PR TITLE
Use parallel execution for rsync

### DIFF
--- a/lib/capistrano/local_precompile.rb
+++ b/lib/capistrano/local_precompile.rb
@@ -36,7 +36,7 @@ namespace :deploy do
 
     desc "Performs rsync to app servers"
     task :rsync do
-      on roles(fetch(:assets_role)) do |server|
+      on roles(fetch(:assets_role)), in: :parallel do |server|
         run_locally do
           execute "#{fetch(:rsync_cmd)} ./#{fetch(:assets_dir)}/ #{server.user}@#{server.hostname}:#{release_path}/#{fetch(:assets_dir)}/" if Dir.exists?(fetch(:assets_dir))
           execute "#{fetch(:rsync_cmd)} ./#{fetch(:packs_dir)}/ #{server.user}@#{server.hostname}:#{release_path}/#{fetch(:packs_dir)}/" if Dir.exists?(fetch(:packs_dir))


### PR DESCRIPTION
I don't think there's a downside to have this enabled by default. Thoughts?