### PR TITLE
Only try to rsync with user if present

### DIFF
--- a/lib/capistrano/local_precompile.rb
+++ b/lib/capistrano/local_precompile.rb
@@ -38,9 +38,11 @@ namespace :deploy do
         run_locally do
           remote_shell = %(-e "ssh -p #{server.port}") if server.port
 
+          rsync_user = (server.user.nil? || server.user.empty?) ? "" : "#{server.user}@"
+
           commands = []
-          commands << "#{fetch(:rsync_cmd)} #{remote_shell} ./#{fetch(:assets_dir)}/ #{server.user}@#{server.hostname}:#{release_path}/#{fetch(:assets_dir)}/" if Dir.exists?(fetch(:assets_dir))
-          commands << "#{fetch(:rsync_cmd)} #{remote_shell} ./#{fetch(:packs_dir)}/ #{server.user}@#{server.hostname}:#{release_path}/#{fetch(:packs_dir)}/" if Dir.exists?(fetch(:packs_dir))
+          commands << "#{fetch(:rsync_cmd)} #{remote_shell} ./#{fetch(:assets_dir)}/ #{rsync_user}#{server.hostname}:#{release_path}/#{fetch(:assets_dir)}/" if Dir.exists?(fetch(:assets_dir))
+          commands << "#{fetch(:rsync_cmd)} #{remote_shell} ./#{fetch(:packs_dir)}/ #{rsync_user}#{server.hostname}:#{release_path}/#{fetch(:packs_dir)}/" if Dir.exists?(fetch(:packs_dir))
 
           commands.each do |command| 
             if dry_run?


### PR DESCRIPTION
This allows you to specify all the config in a `.ssh/config` and not have to pick a user for the server but it should still work if you have a user.